### PR TITLE
Group CMS by path

### DIFF
--- a/src/usr/share/alternc/panel/admin/cmsscanner.php
+++ b/src/usr/share/alternc/panel/admin/cmsscanner.php
@@ -75,12 +75,12 @@ foreach($members as $member) {
 
                 if (!empty($paths_scanned[$path])) {
                     foreach($paths_scanned[$path] as $path_scanned) {
-                        $content[$member['login']][$path_scanned]['fqdn'] = $subdomain['fqdn'];
+                        $content[$member['login']][$path_scanned]['fqdn'][] = $subdomain['fqdn'];
                     }
                     continue;
                 }
 
-                $path_scanned[$path] = [];
+                $paths_scanned[$path] = [];
 
                 $out = array();
                 exec("/usr/bin/cmsscanner cmsscanner:detect --report=/tmp/cmsreport_".$member['login'].".json --versions ".$path, $out);
@@ -89,25 +89,19 @@ foreach($members as $member) {
                 $cmsscanner_result = json_decode($json)[0];
 
                 if(empty($cmsscanner_result)) {
-                    if (empty($content[$member['login']][$path])) {
-                        $content[$member['login']][$path] = [
-                            'cms' => 'unknown',
-                            'version' => 'unknown',
-                            'fqdn' => [$subdomain['fqdn']]
-                        ];
-                    } else {
-                        $content[$member['login']][$path]['fqdn'][] = $subdomain['fqdn'];
-                    }
+                    $content[$member['login']][$path] = [
+                        'cms' => 'unknown',
+                        'version' => 'unknown',
+                        'fqdn' => [$subdomain['fqdn']]
+                    ];
+                    $paths_scanned[$path][] = $path;
                 } else {
-                    if (empty($content[$member['login']][$cmsscanner_result->path])) {
-                        $content[$member['login']][$cmsscanner_result->path] = [
-                            'cms' => $cmsscanner_result->name,
-                            'version' => $cmsscanner_result->version,
-                            'fqdn' => [$subdomain['fqdn']]
-                        ];
-                    } else {
-                        $content[$member['login']][$cmsscanner_result->path]['fqdn'][] = $subdomain['fqdn'];
-                    }
+                    $content[$member['login']][$cmsscanner_result->path] = [
+                        'cms' => $cmsscanner_result->name,
+                        'version' => $cmsscanner_result->version,
+                        'fqdn' => [$subdomain['fqdn']]
+                    ];
+                    $paths_scanned[$path][] = $cmsscanner_result->path;
                 }
             }
         }

--- a/src/usr/share/alternc/panel/admin/cmsscanner.php
+++ b/src/usr/share/alternc/panel/admin/cmsscanner.php
@@ -79,19 +79,26 @@ foreach($members as $member) {
                 $cmsscanner_result = json_decode($json)[0];
 
                 if(empty($cmsscanner_result)) {
-                    $content[$member['login']][$subdomain['fqdn']] = [
-                        'cms' => 'unknown',
-                        'version' => 'unknown',
-                        'path' => $path
-                    ];
+                    if (empty($content[$member['login']][$path])) {
+                        $content[$member['login']][$path] = [
+                            'cms' => 'unknown',
+                            'version' => 'unknown',
+                            'fqdn' => [$subdomain['fqdn']]
+                        ];
+                    } else {
+                        $content[$member['login']][$path]['fqdn'][] = $subdomain['fqdn'];
+                    }
                 } else {
-                    $content[$member['login']][$subdomain['fqdn']] = [
-                        'cms' => $cmsscanner_result->name,
-                        'version' => $cmsscanner_result->version,
-                        'path' => $cmsscanner_result->path
-                    ];
+                    if (empty($content[$member['login']][$cmsscanner_result->path])) {
+                        $content[$member['login']][$cmsscanner_result->path] = [
+                            'cms' => $cmsscanner_result->name,
+                            'version' => $cmsscanner_result->version,
+                            'fqdn' => [$subdomain['fqdn']]
+                        ];
+                    } else {
+                        $content[$member['login']][$cmsscanner_result->path]['fqdn'][] = $subdomain['fqdn'];
+                    }
                 }
-
             }
         }
         $dom->unlock();
@@ -115,23 +122,25 @@ foreach($members as $member) {
     </tr>
 </thead>
 <tbody>
-<?php foreach($content as $member => $sub_domains) { ?>
-    <?php foreach($sub_domains as $fqdn => $sub_domain) { ?>
+<?php foreach($content as $member => $paths) { ?>
+    <?php foreach($paths as $path => $cms) { ?>
         <tr class="lst">
             <td>
                 <?php echo $member; ?>
             </td>
             <td>
-                <?php echo $fqdn; ?>
+                <?php foreach($cms['fqdn'] as $fqdn) {
+                    echo $fqdn."<br/>";
+                } ?>
             </td>            
             <td>
-                <?php echo $sub_domain['cms']; ?>
+                <?php echo $cms['cms']; ?>
             </td>
             <td>
-                <?php echo $sub_domain['version']; ?>
+                <?php echo $cms['version']; ?>
             </td>
             <td>
-                <?php echo $sub_domain['path']; ?>
+                <?php echo $path; ?>
             </td>
         </tr>
     <?php } ?>

--- a/src/usr/share/alternc/panel/admin/cmsscanner.php
+++ b/src/usr/share/alternc/panel/admin/cmsscanner.php
@@ -58,6 +58,7 @@ function get_domain_list($uid = -1)
 
 $members = $admin->get_list();
 $content = [];
+$paths_scanned = [];
 
 foreach($members as $member) {
     $path = [];
@@ -71,6 +72,15 @@ foreach($members as $member) {
         foreach($domain_full['sub'] as $subdomain) {
             if ('DIRECTORY' == $dom->domains_type_target_values($subdomain['type'])) {
                 $path = getuserpath($member['login'])."/".$subdomain['valeur']. " ";
+
+                if (!empty($paths_scanned[$path])) {
+                    foreach($paths_scanned[$path] as $path_scanned) {
+                        $content[$member['login']][$path_scanned]['fqdn'] = $subdomain['fqdn'];
+                    }
+                    continue;
+                }
+
+                $path_scanned[$path] = [];
 
                 $out = array();
                 exec("/usr/bin/cmsscanner cmsscanner:detect --report=/tmp/cmsreport_".$member['login'].".json --versions ".$path, $out);


### PR DESCRIPTION
Some CMS provide multi-site service, in this case we have many fqdn for the same path.

Improvement : 
* Display cms information group by path
* Don't scan twice same path root
